### PR TITLE
Don't use obsoleted functions

### DIFF
--- a/mutant.el
+++ b/mutant.el
@@ -187,9 +187,9 @@ The current directory is assumed to be the project's root otherwise."
        (mapconcat 'identity it " ")))
 
 (defun mutant--colorize-compilation-buffer ()
-  (toggle-read-only)
+  (read-only-mode -1)
   (ansi-color-apply-on-region compilation-filter-start (point))
-  (toggle-read-only))
+  (read-only-mode +1))
 
 (define-compilation-mode mutant-compilation-mode "Mutant Compilation"
   "Compilation mode for Mutant output."
@@ -218,7 +218,7 @@ If there are no files marked, use that under cursor."
   "Run Mutant over MATCH-EXP.
 When called without argument, prompt user."
   (interactive)
-  (let ((match-exp (or match-exp (read-input "Match expression: "))))
+  (let ((match-exp (or match-exp (read-string "Match expression: "))))
     (mutant--run match-exp)))
 
 (defcustom mutant-keymap-prefix (kbd "C-c .")


### PR DESCRIPTION
Using them causes byte-compile warnings.

```
In mutant--colorize-compilation-buffer:
mutant.el:189:8:Warning: `toggle-read-only' is an obsolete function (as of
    24.3); use `read-only-mode' instead.
mutant.el:191:31:Warning: `toggle-read-only' is an obsolete function (as of
    24.3); use `read-only-mode' instead.

In mutant-check-custom:
mutant.el:221:10:Warning: `read-input' is an obsolete function (as of 22.1);
    use `read-string' instead.
```
